### PR TITLE
Feature/add order id on queue item

### DIFF
--- a/src/api/v1/models/queue.py
+++ b/src/api/v1/models/queue.py
@@ -8,6 +8,7 @@ from api.v1.models.page import PageV1Response
 class QueueItemV1Response(BaseModel):
     id: str
     created_at: datetime
+    order_id: str
 
 
 class ListQueueV1Response(PageV1Response):

--- a/src/api/v1/orders.py
+++ b/src/api/v1/orders.py
@@ -282,7 +282,7 @@ async def set_payment_status(
 
     try:
         order_service.set_payment_status(order_id, payment_result.result)
-        if payment_result.result == True:
+        if payment_result.result is True:
             queue_item = QueueItem(order_id=order_id)
             queue_service.register_queue_item(queue_item)
     except NoDocumentsFoundException:

--- a/src/api/v1/orders.py
+++ b/src/api/v1/orders.py
@@ -282,13 +282,13 @@ async def set_payment_status(
 
     try:
         order_service.set_payment_status(order_id, payment_result.result)
-        queue_service.register_queue_item(QueueItem(id=order_id))
+        if payment_result.result == True:
+            queue_item = QueueItem(order_id=order_id)
+            queue_service.register_queue_item(queue_item)
     except NoDocumentsFoundException:
         raise NoDocumentsFoundHTTPException()
     except DataConflictException:
         raise ConflictErrorHTTPException("Order payment can not be modified")
-    except Exception:
-        raise InternalServerErrorHTTPException()
 
     response.status_code = status.HTTP_204_NO_CONTENT
     response.headers[HEADER_CONTENT_TYPE] = (

--- a/src/models/queue.py
+++ b/src/models/queue.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel, ConfigDict
 
 
 class QueueItem(BaseModel):
-    id: str
+    id: str | None = None
     created_at: datetime | None = None
+    order_id: str
 
     model_config = ConfigDict(extra="ignore")

--- a/src/repositories/queue_repository.py
+++ b/src/repositories/queue_repository.py
@@ -14,9 +14,7 @@ class QueueMongoRepository(QueueRepositoryInterface):
 
     def _add(self, queue_item: QueueItem) -> QueueItem:
         queue_item_data = queue_item.model_dump()
-        queue_item_to_db = prepare_document_to_db(
-            queue_item_data, pop_id=False
-        )
+        queue_item_to_db = prepare_document_to_db(queue_item_data)
         self.collection.insert_one(queue_item_to_db)
 
         final_queue_item = queue_item_to_db


### PR DESCRIPTION
### PR Description

#### Summary
This PR add order_id on queue item and fix bug of adding order to queue even if payment fail

#### Changes
Model Updates:

QueueItemV1Response: Added [order_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) field.
QueueItem: Added [order_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) field and made [id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) and [created_at](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) fields optional.
API Endpoint Changes:

set_payment_status: Updated the logic to register a queue item only if the payment result is successful. The [QueueItem](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) is now instantiated with the [order_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) field.
Repository Changes:

QueueMongoRepository: Simplified the [_add](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) method by removing the [pop_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) parameter from the [prepare_document_to_db](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) function call.